### PR TITLE
Underscore instead of hyphen

### DIFF
--- a/lib/PodioObject.php
+++ b/lib/PodioObject.php
@@ -75,6 +75,7 @@ class PodioObject {
     if ($name == 'id' && !empty($this->__id_column)) {
       return empty($this->__attributes[$this->__id_column]) ? null : $this->__attributes[$this->__id_column];
     }
+    $name = $this->hyphenize($name);
     if ($this->has_attribute($name)) {
       // Create DateTime object if necessary
       if ($this->has_property($name) && ($this->__properties[$name]['type'] == 'datetime' || $this->__properties[$name]['type'] == 'date')) {
@@ -86,9 +87,11 @@ class PodioObject {
     }
   }
   public function __isset($name) {
+    $name = $this->hyphenize($name);
     return isset($this->__attributes[$name]);
   }
   public function __unset($name) {
+    $name = $this->hyphenize($name);
     unset($this->__attributes[$name]);
   }
   public function __toString() {
@@ -108,7 +111,6 @@ class PodioObject {
 
   protected function set_attribute($name, $value) {
     if ($this->has_property($name)) {
-
       $property = $this->__properties[$name];
       switch($property['type']) {
         case 'integer':
@@ -291,4 +293,8 @@ class PodioObject {
     return null;
   }
 
+  private function hyphenize($name)
+  {
+    return str_replace('_', '-', $name);
+  }
 }


### PR DESCRIPTION
In PHP you cannot use a variable name with a hyphen in it, while PODIO converts spaces to hyphens. With this modification, user can write variable names with underscores instead of hyphen and still PODIO will get these names with hyphens.
It is safe as PODIO does not allow creating fields with underscores in external_ids.
