### PR TITLE
Added $attributes check in self::DELETE

### DIFF
--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -141,10 +141,10 @@ class Podio {
       case self::DELETE:
         curl_setopt(self::$ch, CURLOPT_CUSTOMREQUEST, self::DELETE);
         self::$headers['Content-type'] = 'application/x-www-form-urlencoded';
-		if ($attributes) {
+        if ($attributes) {
           $query = self::encode_attributes($attributes);
           $url = $url.'?'.$query;
-		}
+        }
         self::$headers['Content-length'] = "0";
         break;
       case self::POST:


### PR DESCRIPTION
Trying to use `PodioItem::delete($itemID, array(), array("silent" => "true")` results in

```
Fatal error: Uncaught PodioBadRequestError: "Invalid value "1?" (string): must be {'1', 'on', 'true', 'y', 'yes', True, '0', 'false', 'n', 'no', 'off', False}”
Request URL: http://api.podio.com/item/123456789?silent=1?
Request Body: null
```

due to the extra question mark being inserted. This solves the problem.
