### PR TITLE
Added $attributes parameter to update_last

### DIFF
--- a/models/PodioView.php
+++ b/models/PodioView.php
@@ -52,7 +52,7 @@ class PodioView extends PodioObject {
    * @see https://developers.podio.com/doc/views/update-last-view-5988251
    */
   public static function update_last($app_id, $attributes = array()) {
-    return Podio::put("/view/app/{$app_id}/last");
+    return Podio::put("/view/app/{$app_id}/last", $attributes);
   }
 
   /**


### PR DESCRIPTION
`$attributes` was missing from the `Podio::put` in `update_last`. Adding it removes the error mentioned in https://help.podio.com/hc/communities/public/questions/202139987-Error-when-using-PodioView-update-last
