### PR TITLE
Fix save item

### DIFF
--- a/models/PodioItem.php
+++ b/models/PodioItem.php
@@ -60,7 +60,7 @@ class PodioItem extends PodioObject {
    * Create or updates an item
    */
   public function save($options = array()) {
-	$this->as_json_without_calculation_fields();
+	$this->as_without_calculation_fields();
     $json_attributes = $this->as_json_without_readonly_fields();
 
     if ($this->id) {
@@ -302,9 +302,9 @@ class PodioItem extends PodioObject {
   }
   
 	/**
-	 * Return json representation without calculation fields. Used for saving items.
+	 * Return representation without calculation fields. Used for saving items.
 	 */
-	public function as_json_without_calculation_fields() {
+	public function as_without_calculation_fields() {
 		$json_attributes = $this->as_json(false);
 		foreach ($this->fields as $key=>$values) {
 			$external_id = $values->external_id;

--- a/models/PodioItem.php
+++ b/models/PodioItem.php
@@ -60,6 +60,7 @@ class PodioItem extends PodioObject {
    * Create or updates an item
    */
   public function save($options = array()) {
+	$this->as_json_without_calculation_fields();
     $json_attributes = $this->as_json_without_readonly_fields();
 
     if ($this->id) {
@@ -299,5 +300,20 @@ class PodioItem extends PodioObject {
   public static function revert_to_revision($item_id, $revision, $attributes = array()) {
     return Podio::post("/item/{$item_id}/revision/{$revision}/revert_to", $attributes);
   }
+  
+	/**
+	 * Return json representation without calculation fields. Used for saving items.
+	 */
+	public function as_json_without_calculation_fields() {
+		$json_attributes = $this->as_json(false);
+		foreach ($this->fields as $key=>$values) {
+			$external_id = $values->external_id;
+			$type = $values->type;
+			//echo $external_id."==>"."type=".$type."id:".$this->id."exist or not:".$json_attributes['fields'][$external_id]."</br></br>";
+			if( $this->id && $type == "calculation" &&  isset($json_attributes['fields'][$external_id])) {
+				unset ($this->fields[$external_id]);
+			}
+		}
+	}
 
 }


### PR DESCRIPTION
This change allows avoiding the bug about saving an item with calculation fields.

`$item = PodioItem::get($item_id);` 
`// ..... operations`
`$item->save();`
The code above used to throw an exception when the fetched has a calculation field
