### PR TITLE
Bug under PodioItemDiff::get_for

### DIFF
--- a/models/PodioItemDiff.php
+++ b/models/PodioItemDiff.php
@@ -6,7 +6,7 @@ class PodioItemDiff extends PodioObject {
   public function __construct($attributes = array()) {
     $this->property('field_id', 'integer');
     $this->property('type', 'string');
-    $this->property('external_id', 'integer');
+    $this->property('external_id', 'string');
     $this->property('label', 'string');
     $this->property('from', 'array');
     $this->property('to', 'array');


### PR DESCRIPTION
This bug caused external_id to be 0 for all fields that changed.

Changed external_id from integer to string in the model to fix the bug.