### PR TITLE
Update PodioSpaceMember.php

### DIFF
--- a/models/PodioSpaceMember.php
+++ b/models/PodioSpaceMember.php
@@ -64,5 +64,13 @@ class PodioSpaceMember extends PodioObject {
   public static function add($space_id, $attributes = array()) {
     return Podio::post("/space/{$space_id}/member/", $attributes);
   }
+  
+    /**
+  * @see https://developers.podio.com/doc/space-members/request-space-membership-6146231
+  */
+
+ public static function request($space_id) {
+    return Podio::post("/space/{$space_id}/member_request/");
+  }
 
 }


### PR DESCRIPTION
The request method has been missing for PHP.
Although it will throw an ugly error when the user is already member of the workspace
Fatal error: Uncaught PodioForbiddenError: "The user with id 123 does not have the right request_membership on space with id 345"