### PR TITLE
Issue#163 - Missing options field in PodioItemDiff

### DIFF
--- a/models/PodioItemDiff.php
+++ b/models/PodioItemDiff.php
@@ -10,6 +10,7 @@ class PodioItemDiff extends PodioObject {
     $this->property('label', 'string');
     $this->property('from', 'array');
     $this->property('to', 'array');
+    $this->property('config', 'hash');
 
     $this->init($attributes);
   }


### PR DESCRIPTION
Fix missing options field data in PodioItemDiff::get_for on Issue #163 