### PR TITLE
changing packagist vendor name to podio-community

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,17 @@
 {
-  "name": "podio/podio-php",
+  "name": "podio-community/podio-php",
   "description": "PHP Client for Podio API",
   "keywords": ["podio"],
   "homepage": "http://github.com/podio/podio-php",
   "license": "MIT",
   "authors": [
     {
+      "name": "Daniel Schreiber",
+      "email": "daniel-schreiber@gmx.de"
+    },
+    {
       "name": "Andreas Haugstrup Pedersen",
-      "email": "haugstrup@podio.com",
-      "role": "Developer"
+      "email": "haugstrup@podio.com"
     }
   ],
   "require": {


### PR DESCRIPTION
This should enable to publish releases to packagist, as discussed in #165.

Additionally I added myself as a maintainer, to assure at least one current maintainer is included. If anyone else is OK with beeing mentioned, I'd be happy to include more people, but I did not want to include personal information without asking..