### PR TITLE
Use late binding for static Podio method invocation

### DIFF
--- a/lib/Podio.php
+++ b/lib/Podio.php
@@ -296,7 +296,7 @@ class Podio {
         if (strstr($body['error_description'], 'expired_token') || strstr($body['error'], 'invalid_token')) {
           if (self::$oauth->refresh_token) {
             // Access token is expired. Try to refresh it.
-            if (static::authenticate('refresh_token', array('refresh_token' => self::$oauth->refresh_token))) {
+            if (static::refresh_access_token()) {
               // Try the original request again.
               return static::request($method, $original_url, $attributes);
             }


### PR DESCRIPTION
Using late binding (`static::`) instead of early binding (`self::`) for method invocations in Podio enables to 'overwrite' methods, e.g. using https://github.com/goaop/framework .

[Btw: with that you can do smooth retries on errors etc ;) ]