### PR TITLE
Full doc run for invalid / broken links and old references to podio repo

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,11 +26,11 @@
           </ul>
         </nav>
         <p>You have found the official PHP client library for <a href="https://developers.podio.com/">Podio</a>. It covers all aspects of the Podio API.</p>
-        <p>For help and bugs <a href="https://github.com/podio/podio-php/issues">create an issue on GitHub</a>.</p>
+        <p>For help and bugs <a href="https://github.com/podio-community/podio-php/issues">create an issue on GitHub</a>.</p>
         <ul class="buttons">
-          <li><a class="download" href="https://github.com/podio/podio-php/releases">Download</a></li>
-          <li><a class="packagist" href="https://packagist.org/packages/podio/podio-php">Packagist</a></li>
-          <li><a class="github" href="https://github.com/podio/podio-php">GitHub</a></li>
+          <li><a class="download" href="https://github.com/podio-community/podio-php/releases">Download</a></li>
+          <li><a class="packagist" href="https://packagist.org/packages/podio-community/podio-php">Packagist</a></li>
+          <li><a class="github" href="https://github.com/podio-community/podio-php">GitHub</a></li>
         </ul>
       </header>
       <main>

--- a/api-requests/index.md
+++ b/api-requests/index.md
@@ -6,7 +6,7 @@ active: api
 Each of the classes in the `models/` folder has a collection of static functions. You use these whenever you want to make API calls. **Important note:** When you are working with Apps, Items, AppField or ItemField classes you can take advantage of powerful instance methods. This will make your life easier. Read more under [Working with apps & items]({{site.baseurl}}/items).
 
 ## Reading the API reference
-You can find API reference documentation at [https://developers.podio.com/doc](https://developers.podio.com/doc) it lists all available API operations possible. Almost all of them have been added to podio-php. If you need one added feel free to open a pull request on the [GitHub Project](https://github.com/podio/podio-php).
+You can find API reference documentation at [https://developers.podio.com/doc](https://developers.podio.com/doc) it lists all available API operations possible. Almost all of them have been added to podio-php. If you need one added feel free to open a pull request on the [GitHub Project](https://github.com/podio-community/podio-php).
 
 When you view an individual API operation (e.g. [Search in space](https://developers.podio.com/doc/search/search-in-space-22479)) you can see sample PHP code at the top. You can use this as a starting point when making API requests. For Search in space it's:
 

--- a/changelog/index.md
+++ b/changelog/index.md
@@ -4,9 +4,14 @@ active: changelog
 ---
 # Release notes
 
+## 4.4.0 
+
+* This is the first release under the new package name podio-community/podio-php. It contains several fixes and minor improvements and should generally be backwards compatible to podio/podio-php v4.3.0.
+* Several fixes and improvements: [See in repository](https://github.com/podio-community/podio-php/compare/4.3.0...v4.4.0)
+
 ## 4.3.0
 
-* Add support for Flows (https://developers.podio.com/doc/flows)
+* Add support for [Flows](https://developers.podio.com/doc/flows)
 
 ## 4.2.0
 

--- a/debug/index.md
+++ b/debug/index.md
@@ -6,7 +6,7 @@ active: debug
 
 <span class="note">Using debug mode can also be used to diagnose performance problems where you are making more requests than you intended.</span>
 
-Podio-php will throw exceptions when something goes predictably wrong. For example if you try to update something you don't have permissions to update, if you don't include required attributes, if you hit the rate limit etc. All exceptions extends `PodioError` and you can see a list in [`PodioError.php`](https://github.com/podio/podio-php/blob/master/lib/PodioError.php)
+Podio-php will throw exceptions when something goes predictably wrong. For example if you try to update something you don't have permissions to update, if you don't include required attributes, if you hit the rate limit etc. All exceptions extends `PodioError` and you can see a list in [`PodioError.php`](https://github.com/podio-community/podio-php/blob/master/lib/error)
 
 All these exceptions will end up in your PHP error log so if you just see a blank screen look there for them (or configure PHP to print errors to the screen).
 

--- a/index.md
+++ b/index.md
@@ -11,9 +11,9 @@ You need PHP 5.3+ with curl and openssl extensions enabled. There are no externa
 There are many moving parts under the hood and you should be familiar with the basics of HTTP and Object-Oriented Programming (OOP) in PHP before diving in. If you are new to OOP there are some resources linked in [this answer on StackOverflow](http://stackoverflow.com/questions/5646356/php-oop-getting-started) to get you started. If you are not very familiar with PHP or the basics of HTTP a podio-php project will most likely be a poor beginners project. It would be best to seek out more basic PHP projects first.
 
 ## Installation
-If you are using [Composer](http://getcomposer.org/) there's [a package on Packagist](https://packagist.org/packages/podio/podio-php). There's an autoloader so you don't have to do anything else if you are using Composer's autoloader.
+If you are using [Composer](http://getcomposer.org/) there's [a package on Packagist](https://packagist.org/packages/podio-community/podio-php). There's an autoloader so you don't have to do anything else if you are using Composer's autoloader.
 
-If you are not using Composer you must [download a copy of podio-php](https://github.com/podio/podio-php/releases) and include it manually:
+If you are not using Composer you must [download a copy of podio-php](https://github.com/podio-community/podio-php/releases) and include it manually:
 
 {% highlight php startinline %}
 require_once '/path/to/podio-php/PodioAPI.php';

--- a/objects/index.md
+++ b/objects/index.md
@@ -10,7 +10,7 @@ Most API calls return a Podio object that matches the class you called a static 
 
 Once you have a Podio* object you might be tempted to simply `var_dump` it to see which properties are available. This would be a mistake. Due to the dynamic nature of the data structures returned from the Podio API Podio* objects use magic getters and setters. With a `var_dump` you will just see the internal data structure which is cumbersome to work with.
 
-To see which properties you can access on an object type open the class file and look at the constructor. The class files are all located in the [models folder](https://github.com/podio/podio-php/tree/master/models). As an example look at [PodioTask](https://github.com/podio/podio-php/blob/master/models/PodioTask.php). You can see three methods being called to setup the properties:
+To see which properties you can access on an object type open the class file and look at the constructor. The class files are all located in the [models folder](https://github.com/podio-community/podio-php/tree/master/models). As an example look at [PodioTask](https://github.com/podio-community/podio-php/blob/master/models/PodioTask.php). You can see three methods being called to setup the properties:
 
 * `$this->property()` declares a normal property.
 * `$this->has_one()` declares a one-to-one relationship to another Podio* object. E.g. PodioTask has a property `created_by` which contains a single `PodioByLine` object.

--- a/webhooks/index.md
+++ b/webhooks/index.md
@@ -41,7 +41,7 @@ foreach ($hooks as $hook) {
 
 ## Troubleshooting webhooks
 When webhooks fail to show up it's typically for one of the following reasons:
-* Not a public URL. Webhooks must be available on the public internet. You can test them locally using tools like [localtunnel](http://progrium.com/localtunnel/) or [ProxyLocal](http://proxylocal.com/). For the same reason they cannot reside behind your corporate firewall.
+* Not a public URL. Webhooks must be available on the public internet. You can test them locally using tools like [RequestBin](https://requestbin.com/) or [Webhooks.site](https://webhook.site/). For the same reason they cannot reside behind your corporate firewall.
 * Not on a standard port. Webhooks must be served on port 80 for http and 443 for https.
 * Incoming requests blocked by firewall/hosting provider. Your IT department or hosting provider may be blocking webhooks.
 * Query string parameters will be converted to POST parameters. Because webhooks are POST requests any query string parameters will be converted to a POST parameter. If your URL is `http://example.com/hook?foo=bar` you will not be able to use `$_GET['foo']` - use `$_POST['foo']` instead.


### PR DESCRIPTION
I've got the time to read all the docs. My main focus was the links pointing to the old repo and old packagist. Also fixed broken links to webhooks testing sites.

I believe it cloeses #177  let me know if something else needs a fix.