### PR TITLE
add type of return value to function

### DIFF
--- a/lib/PodioCollection.php
+++ b/lib/PodioCollection.php
@@ -36,7 +36,7 @@ class PodioCollection implements IteratorAggregate, ArrayAccess, Countable
     /**
      * Implements Countable
      */
-    public function count()
+    public function count(): int
     {
         return count($this->__items);
     }


### PR DESCRIPTION
since php 8.1 deprecation warnings are generated in this case, so this is to make it work without the warning.