### PR TITLE
PodioError.php fix for null requests

### DIFF
--- a/lib/error/PodioError.php
+++ b/lib/error/PodioError.php
@@ -10,7 +10,7 @@ class PodioError extends Exception
         $this->body = json_decode($body, true);
         $this->status = $status;
         $this->url = $url;
-        $this->request = $this->body['request'];
+        $this->request = $this->body['request'] ?? null;
         parent::__construct(get_class($this), 1, null);
     }
 


### PR DESCRIPTION
If $this->body['request'] doesn't exist then set $this->request to null