### PR TITLE
doc: add migration guid + remove obsolete properties $headers/$secret…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 [7.0.0](#v7.0.0) / [unreleased]
 ==================
 * BREAKING: Replace static `Podio` client with instantiable `PodioClient` class. #228
-* BREAKING: Replace update/save methods on instances with static methods #234
+* BREAKING: Replace `save` (and `completed`/`incompleted`/`destroy` on `PodioTask`) methods on instances with static methods #234
+* BREAKING: Remove obsolete `PodioClient::secret` and `PodioClient::headers` properties.
+* BREAKING: `Podio::debug` changed from public to protected: use `PodioClient::set_debug(..)`
+* See [migration guide](https://github.com/podio-community/podio-php/blob/master/MIGRATION_GUIDE_v7.md) for details.
 
 [6.1.1](#v6.1.1) / 2023-06-12
 ==================

--- a/MIGRATION_GUIDE_v7.md
+++ b/MIGRATION_GUIDE_v7.md
@@ -1,0 +1,54 @@
+# Migration Guide for updating from v6 to v7
+
+1. Instead of calling `Podio::setup(..)` you should create an instance of `PodioClient` and pass it to other methods.
+   ```php
+    // Before:
+    Podio::setup($client_id, $client_secret, $options);
+    Podio::authenticate_with_password($username, $password);
+    
+    // After:
+    $client = new PodioClient($client_id, $client_secret, $options);
+    $client->authenticate_with_password($username, $password);
+   ```
+2. All operations take an instance of `PodioClient` as the first argument.
+   ```php
+   // Before:
+   PodioItem::get(123);
+   
+   // After:
+   PodioItem::get($client, 123);
+   ```
+3. All operations are now static methods on the model classes.
+   ```php
+    // Before:
+    $item->save();
+    
+    // After:
+    PodioItem::save($client, $item);
+   ```
+   Besides the `save` methods in almost all objects, the following methods have changed:
+   ```php
+    // Before: 
+    $podioTask->completed();
+    // After:
+    PodioTask::complete($client, $podioTask->task_id);
+    
+    // Before:
+    $podioTask->incompleted();
+    // After:
+    PodioTask::incomplete($client, $podioTask->task_id);
+    
+    // Before:
+    $podioTask->destroy();
+    // After:
+    PodioTask::delete($client, $podioTask->task_id);
+   ```
+
+## Notes
+
+The following regex might help you find all relevant places in your codebase:
+
+```regex
+Podio\w*::\w+\(|->save\(|->completed\(\)|->incompleted\(\)|->destroy\(\)
+```
+

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-test:
-	phpunit --bootstrap vendor/autoload.php tests

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ require __DIR__ . '/vendor/autoload.php';
 
 $client = new PodioClient($client_id, $client_secret);
 $client->authenticate_with_app($app_id, $app_token);
-$items = PodioItem::filter($app_id, $client);
+$items = PodioItem::filter($client, $app_id);
 
-print "My app has " . count($items) . " items";
+print "My app has " . $items->total . " items";
 ```
 
 ## Contribute

--- a/lib/PodioClient.php
+++ b/lib/PodioClient.php
@@ -15,6 +15,7 @@ class PodioClient
     protected $debug = false;
     public $logger;
     public $session_manager;
+    /** @var ?PodioResponse */
     public $last_response;
     public $auth_type;
     /** @var \GuzzleHttp\Client */
@@ -22,12 +23,10 @@ class PodioClient
     protected $url;
     protected $client_id;
     protected $client_secret;
-    protected $secret;
-    protected $headers;
     /** @var \Psr\Http\Message\ResponseInterface */
     private $last_http_response;
 
-    public const VERSION = '6.1.0';
+    public const VERSION = '7.0.0';
 
     public const GET = 'GET';
     public const POST = 'POST';


### PR DESCRIPTION
… from PodioClient

see #235

I think v7 is becoming stable enough for a release slowly? If anyone is planning on testing the latest beta version, we should of course wait for that..