### PR TITLE
Require guzzlehttp/psr7 >= 1.7.0 for Util class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
   "require": {
     "php": "^7.3 || ^8.0",
     "guzzlehttp/guzzle": ">=6.2.0",
+    "guzzlehttp/psr7": ">=1.7.0",
     "ext-json": "*"
   },
   "suggest": {


### PR DESCRIPTION
The PodioClient class depends on the `\GuzzleHttp\Psr7\Utils` class, however this was not included in the existing requirements, since the `guzzlehttp/guzzle` requirement of `>=6.2.0` only requires `guzzlehttp/psr7:~1.1`, so this will cause a "Class not found" error when attempting to load the Util class.

This change explicitly adds the `guzzlehttp/psr7:>=1.7.0` requirement, however this could also be acheived by bumping the `guzzlehttp/guzzle` requirement, since anything less than `6.5.8` has a security vulnerability.