### PR TITLE
fix: correct handling of null values for date/datetime fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,12 @@
-[7.0.0](#v7.0.0) / [unreleased]
+[7.0.2](#v7.0.2) / [UNRELEASED]
+==================
+* Bugfix: Correct handling of `null` values for date/datetime fields. #244
+
+[7.0.1](#v7.0.1) / [2023-11-07]
+==================
+* Bugfix: Require guzzlehttp/psr7 >= 1.7.0 for Util class by @toby-griffiths in #243.
+
+[7.0.0](#v7.0.0) / [2023-08-22]
 ==================
 * BREAKING: Replace static `Podio` client with instantiable `PodioClient` class. #228
 * BREAKING: Replace `save` (and `completed`/`incompleted`/`destroy` on `PodioTask`) methods on instances with static methods #234

--- a/lib/PodioObject.php
+++ b/lib/PodioObject.php
@@ -99,7 +99,7 @@ class PodioObject
         }
         if ($this->has_attribute($name)) {
             // Create DateTime object if necessary
-            if ($this->has_property($name) && ($this->__properties[$name]['type'] == 'datetime' || $this->__properties[$name]['type'] == 'date')) {
+            if ($this->has_property($name) && ($this->__properties[$name]['type'] == 'datetime' || $this->__properties[$name]['type'] == 'date') && !empty($this->__attributes[$name])) {
                 $tz = new DateTimeZone('UTC');
                 return DateTime::createFromFormat($this->date_format_for_property($name), $this->__attributes[$name], $tz);
             }

--- a/tests/PodioObjectTest.php
+++ b/tests/PodioObjectTest.php
@@ -314,4 +314,15 @@ class PodioObjectTest extends TestCase
         $this->assertSame($instance, $relationship['instance']);
         $this->assertSame('fields', $relationship['property']);
     }
+
+    public function test_null_with_datetime(): void
+    {
+        $object = new PodioObject();
+        $object->property('datetime_property', 'datetime');
+        $object->datetime_property = null;
+
+        $this->assertNull($object->datetime_property);
+        // expect no (php deprecation) warning:
+        $this->expectOutputRegex('/^\s*$/');
+    }
 }


### PR DESCRIPTION
* no deprecation warning (php 8)
* return null (instead of false)